### PR TITLE
A few range updates and fsr fix

### DIFF
--- a/firmware/data/settings.json
+++ b/firmware/data/settings.json
@@ -2,7 +2,7 @@
     "settings": [
         {
             "name": "fsr_offset",
-            "value": 0
+            "value": 2000
         }
     ]
 }

--- a/firmware/data/settings.json
+++ b/firmware/data/settings.json
@@ -2,7 +2,7 @@
     "settings": [
         {
             "name": "fsr_offset",
-            "value": 2000
+            "value": 1900
         }
     ]
 }

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -14,7 +14,7 @@ description = T-Stick
 [common]
 lib_deps = 
 	https://github.com/Puara/puara-gestures.git
-	https://github.com/mathiasbredholt/libmapper-arduino.git#v0.3
+	https://github.com/libmapper/libmapper-arduino.git
 	https://github.com/Puara/puara-module.git
 	https://github.com/CAP1Sup/Arduino_LSM9DS1.git
 	tinypico/TinyPICO Helper Library@^1.4.0

--- a/firmware/src/fsr.cpp
+++ b/firmware/src/fsr.cpp
@@ -10,9 +10,15 @@ int Fsr::initFsr(int &fsr_pin, int offsetValue){
 
 int Fsr::readFsr() {
     Fsr::value = analogRead(Fsr::pin);
-    Fsr::normValue = constrain((Fsr::value - Fsr::offset) / (4095 - Fsr::offset), 0, 1);
-    Fsr::cookedValue = max(Fsr::value - Fsr::offset, 0.0f);
+    Fsr::normValue = mapFloat(Fsr::value, Fsr::offset, 4095, 0, 1);
     return 1;
+}
+
+float Fsr::mapFloat(float x, float in_min, float in_max, float out_min, float out_max) {
+    x = constrain(x, in_min, in_max);
+    float result = (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+    result = constrain(result, out_min, out_max);
+    return result;
 }
 
 float Fsr::getValue() {
@@ -21,10 +27,6 @@ float Fsr::getValue() {
 
 float Fsr::getNormValue() {
     return Fsr::normValue;
-}
-
-float Fsr::getCookedValue() {
-    return Fsr::cookedValue;
 }
 
 int Fsr::getOffset(){

--- a/firmware/src/fsr.cpp
+++ b/firmware/src/fsr.cpp
@@ -11,7 +11,7 @@ int Fsr::initFsr(int &fsr_pin, int offsetValue){
 int Fsr::readFsr() {
     Fsr::value = analogRead(Fsr::pin);
     Fsr::normValue = constrain((Fsr::value - Fsr::offset) / (4095 - Fsr::offset), 0, 1);
-    Fsr::cookedValue = Fsr::value - Fsr::offset;
+    Fsr::cookedValue = max(Fsr::value - Fsr::offset, 0.0f);
     return 1;
 }
 

--- a/firmware/src/fsr.h
+++ b/firmware/src/fsr.h
@@ -12,12 +12,12 @@ class Fsr {
         float normValue = 0;
         float cookedValue = 0;
         int offset = 0;
+        float mapFloat(float x, float in_min, float in_max, float out_min, float out_max);
     public:
         int initFsr(int &fsr_pin, int offsetValue);
         int readFsr();
         float getValue();
         float getNormValue();
-        float getCookedValue();
         int getOffset();
         int setOffset(int offsetValue);
 };

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -185,8 +185,8 @@ int generic_handler(const char *path, const char *types, lo_arg ** argv,
 
 struct Lm {
     mpr_sig fsr = 0;
-    float fsrMax = 4900;
-    float fsrMin = 0;
+    int fsrMax = 4900;
+    int fsrMin = 2000;
     mpr_sig accel = 0;
     float accelMax[3] = {50, 50, 50};
     float accelMin[3] = {-50, -50, -50};
@@ -203,8 +203,8 @@ struct Lm {
     float yprMax[3] = {180, 180, 180};
     float yprMin[3] = {-180, -180, -180};
     mpr_sig shake = 0;
-    float shakeMax[3] = {50, 50, 50};
-    float shakeMin[3] = {-50, -50, -50};
+    float shakeMax[3] = {100, 100, 100};
+    float shakeMin[3] = {0, 0, 0};
     mpr_sig jab = 0;
     float jabMax[3] = {50, 50, 50};
     float jabMin[3] = {-50, -50, -50};
@@ -214,8 +214,8 @@ struct Lm {
     float brushMin[4] = {-50, -50, -50, -50};
     mpr_sig rub = 0;
     mpr_sig multirub = 0;
-    float rubMax[4] = {50, 50, 50, 50};
-    float rubMin[4] = {-50, -50, -50, -50};
+    float rubMax[4] = {5, 5, 5, 5};
+    float rubMin[4] = {0, 0, 0, 0};
     mpr_sig touch = 0;
     int touchMax[TSTICK_SIZE]; // Initialized in setup()
     int touchMin[TSTICK_SIZE];
@@ -335,7 +335,7 @@ void setup() {
 
     std::cout << "    Initializing Libmapper device/signals... ";
     lm_dev = mpr_dev_new(puara.get_dmi_name().c_str(), 0);
-    lm.fsr = mpr_sig_new(lm_dev, MPR_DIR_OUT, "raw/fsr", 1, MPR_FLT, "un", &lm.fsrMin, &lm.fsrMax, 0, 0, 0);
+    lm.fsr = mpr_sig_new(lm_dev, MPR_DIR_OUT, "raw/fsr", 1, MPR_INT32, "un", &lm.fsrMin, &lm.fsrMax, 0, 0, 0);
     lm.accel = mpr_sig_new(lm_dev, MPR_DIR_OUT, "raw/accel", 3, MPR_FLT, "m/s^2",  &lm.accelMin, &lm.accelMax, 0, 0, 0);
     lm.gyro = mpr_sig_new(lm_dev, MPR_DIR_OUT, "raw/gyro", 3, MPR_FLT, "rad/s", &lm.gyroMin, &lm.gyroMax, 0, 0, 0);
     lm.magn = mpr_sig_new(lm_dev, MPR_DIR_OUT, "raw/mag", 3, MPR_FLT, "uTesla", &lm.magnMin, &lm.magnMax, 0, 0, 0);
@@ -496,7 +496,7 @@ void loop() {
     if (sensors.battery != battery.percentage) {sensors.battery = battery.percentage; event.battery = true; } else { event.battery = false; }
 
     // updating libmapper signals
-    mpr_sig_set_value(lm.fsr, 0, 1, MPR_FLT, &sensors.fsr);
+    mpr_sig_set_value(lm.fsr, 0, 1, MPR_INT32, &sensors.fsr);
     mpr_sig_set_value(lm.accel, 0, 3, MPR_FLT, &sensors.accl);
     mpr_sig_set_value(lm.gyro, 0, 3, MPR_FLT, &sensors.gyro);
     mpr_sig_set_value(lm.magn, 0, 3, MPR_FLT, &sensors.magn);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -200,8 +200,8 @@ struct Lm {
     float quatMax[4] = {1, 1, 1, 1};
     float quatMin[4] = {-1, -1, -1, -1};
     mpr_sig ypr = 0;
-    float yprMax[3] = {180, 180, 180};
-    float yprMin[3] = {-180, -180, -180};
+    float yprMax[3] = {M_PI, M_PI_2, M_PI};
+    float yprMin[3] = {-M_PI, -M_PI_2, -M_PI};
     mpr_sig shake = 0;
     float shakeMax[3] = {100, 100, 100};
     float shakeMin[3] = {0, 0, 0};

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -185,8 +185,8 @@ int generic_handler(const char *path, const char *types, lo_arg ** argv,
 
 struct Lm {
     mpr_sig fsr = 0;
-    int fsrMax = 4900;
-    int fsrMin = 2000;
+    int fsrMax = 2000;
+    int fsrMin = 0;
     mpr_sig accel = 0;
     float accelMax[3] = {50, 50, 50};
     float accelMin[3] = {-50, -50, -50};


### PR DESCRIPTION
- Shake range fix (should be 0-100 not -50-50)
- Rub range fix (should be 0-5 not -50-50)
- YPR ranges should be in radians after sensor fusion updates
- FSR libmapper fix, was using floats instead of ints for setting signal value
- Use FSR offset as 2000, clip negative values when cooking
- Use libmapper/libmapper-arduino which has been updated to libmapper version 2.3