### PR TITLE
Call mpr_dev_update_maps() once all signals have been updated.

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -530,6 +530,9 @@ void loop() {
         mpr_sig_set_value(lm.touch, 0, capsense.touchStripsSize, MPR_INT32, &capsense.data);
     #endif
 
+    // when finished updating libmapper signal values
+    mpr_dev_update_maps(lm_dev);
+
     // Sending continuous OSC messages
     if (puara.IP1_ready()) {
 


### PR DESCRIPTION
This change will cause libmapper to send updates to mapped peers immediately rather than waiting for the next call to mpr_dev_poll().